### PR TITLE
Add recv peek mode

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,6 +13,7 @@ TESTS = \
 	test-ptyterm-help.sh \
 	test-ptyterm-help-errors.sh \
 	test-ptyterm-help-format.sh \
+	test-ptyterm-recv-peek-errors.sh \
 	test-ptyterm-daemon-lifecycle.sh \
 	test-ptyterm-status-format.sh \
 	test-ptyterm-attach-nonblock.sh \

--- a/src/ptyterm-control.h
+++ b/src/ptyterm-control.h
@@ -41,6 +41,10 @@ enum ptyterm_session_state {
   PTYTERM_SESSION_EXITED = 3,
 };
 
+enum ptyterm_recv_flags {
+  PTYTERM_RECV_FLAG_PEEK = 1u << 0,
+};
+
 struct ptyterm_message_header {
   uint32_t magic;
   uint16_t version;
@@ -105,6 +109,7 @@ struct ptyterm_send_response {
 struct ptyterm_recv_request {
   int32_t session_id;
   uint32_t max_bytes;
+  uint32_t flags;
 };
 
 struct ptyterm_recv_response {

--- a/src/ptyterm.c
+++ b/src/ptyterm.c
@@ -132,6 +132,7 @@ static void print_text_help(FILE *out, const char *program_name) {
   fprintf(out, "      --send=DATA     : send decoded bytes to one session\n");
   fprintf(out, "      --recv          : receive buffered output from one session\n");
   fprintf(out, "      --recv-size=N   : maximum bytes returned by --recv\n");
+  fprintf(out, "      --peek          : inspect buffered output without advancing recv\n");
   fprintf(out, "      --session=ID    : select one session for management operations\n");
   fprintf(out, "      --rows=N        : rows for --resize (alias: --lines)\n");
   fprintf(out, "      --cols=N        : cols for --resize\n");
@@ -248,6 +249,11 @@ static void print_yaml_help(FILE *out, const char *program_name) {
   fprintf(out, "      argument: none\n");
   fprintf(out, "      requires: [--session]\n");
   fprintf(out, "      description: Receive buffered output from one session.\n");
+  fprintf(out, "    - long: --peek\n");
+  fprintf(out, "      short: null\n");
+  fprintf(out, "      argument: none\n");
+  fprintf(out, "      requires: [--recv]\n");
+  fprintf(out, "      description: Read buffered output without advancing the recv cursor.\n");
   fprintf(out, "    - long: --recv-size\n");
   fprintf(out, "      short: null\n");
   fprintf(out, "      argument: N\n");
@@ -876,7 +882,7 @@ static int run_send_client(const char *socket_path, int session_id,
 }
 
 static int run_recv_client(const char *socket_path, int session_id,
-                           uint32_t recv_size) {
+                           uint32_t recv_size, int recv_peek) {
   char default_socket_path[PTYTERM_SOCKET_PATH_MAX];
   char payload[8192];
   struct ptyterm_recv_request request;
@@ -888,6 +894,7 @@ static int run_recv_client(const char *socket_path, int session_id,
 
   request.session_id = session_id;
   request.max_bytes = recv_size;
+  request.flags = recv_peek ? PTYTERM_RECV_FLAG_PEEK : 0;
   fd = connect_daemon_socket(socket_path, default_socket_path, 1);
   if (fd == -1) {
     perror(socket_path);
@@ -1550,6 +1557,7 @@ int main(int argc, char *const argv[]) {
   int help_requested = 0;
   int help_format = PTYTERM_HELP_FORMAT_TEXT;
   int list_requested = 0;
+  int recv_peek = 0;
   int resize_requested = 0;
   int recv_requested = 0;
   int status_format = PTYTERM_STATUS_FORMAT_KV;
@@ -1569,6 +1577,7 @@ int main(int argc, char *const argv[]) {
       OPT_SEND = 1000,
       OPT_RECV,
       OPT_RECV_SIZE,
+      OPT_PEEK,
       OPT_DAEMON_STATUS,
       OPT_DAEMON_STOP,
       OPT_HELP_FORMAT,
@@ -1590,6 +1599,7 @@ int main(int argc, char *const argv[]) {
                        {"send", required_argument, NULL, OPT_SEND},
                        {"recv", no_argument, NULL, OPT_RECV},
                        {"recv-size", required_argument, NULL, OPT_RECV_SIZE},
+                       {"peek", no_argument, NULL, OPT_PEEK},
                        {"socket", required_argument, NULL, 's'},
                        {"buffer-info", no_argument, NULL, 'B'},
                        {"list", no_argument, NULL, 'L'},
@@ -1653,6 +1663,9 @@ int main(int argc, char *const argv[]) {
     case OPT_RECV:
       recv_requested = 1;
       break;
+    case OPT_PEEK:
+      recv_peek = 1;
+      break;
     case OPT_RECV_SIZE:
       recv_size = (uint32_t)strtoul(optarg, &p, 0);
       if (optarg == p || *p != '\0' || recv_size == 0)
@@ -1711,7 +1724,10 @@ int main(int argc, char *const argv[]) {
     return usage_error(argv[0], "output and append options are exclusive");
   }
 
-    if ((attach_requested != 0) + (create_requested != 0) +
+  if (recv_peek && !recv_requested)
+    return usage_error(argv[0], "--peek requires --recv");
+
+  if ((attach_requested != 0) + (create_requested != 0) +
       (daemon_status_requested != 0) + (daemon_stop_requested != 0) +
       (detach_requested != 0) + (list_requested != 0) +
       (resize_requested != 0) +
@@ -1721,7 +1737,7 @@ int main(int argc, char *const argv[]) {
     return usage_error(argv[0], "select only one management operation");
   }
 
-    if (attach_requested || create_requested || daemon_status_requested ||
+  if (attach_requested || create_requested || daemon_status_requested ||
       daemon_stop_requested || detach_requested ||
       resize_requested ||
       list_requested || buffer_info_requested ||
@@ -1770,7 +1786,7 @@ int main(int argc, char *const argv[]) {
     if (send_data != NULL)
       return run_send_client(socket_path, session_id, send_data);
     if (recv_requested)
-      return run_recv_client(socket_path, session_id, recv_size);
+      return run_recv_client(socket_path, session_id, recv_size, recv_peek);
     return run_buffer_info_client(socket_path, session_id, status_format);
   }
 

--- a/src/ptytermd.c
+++ b/src/ptytermd.c
@@ -777,13 +777,16 @@ static int handle_recv_request(int client_fd, struct ptyterm_daemon_state *state
   response->oldest_available_offset = oldest_offset;
   response->returned_bytes = (uint32_t)returned_bytes;
   response->end_offset = start_offset + returned_bytes;
-  response->next_recv_offset = response->end_offset;
+  response->next_recv_offset =
+      (request->flags & PTYTERM_RECV_FLAG_PEEK) != 0 ? session->recv_offset
+                                                     : response->end_offset;
   response->truncated = session->recv_offset < oldest_offset;
   snprintf(response->reason, sizeof(response->reason), "%s",
            returned_bytes == request->max_bytes ? "size_reached" :
            (session->state == PTYTERM_SESSION_EXITED ? "session_exited" :
                                                      (response->truncated ? "truncated_gap" : "ok")));
-  session->recv_offset = response->next_recv_offset;
+  if ((request->flags & PTYTERM_RECV_FLAG_PEEK) == 0)
+    session->recv_offset = response->next_recv_offset;
 
   returned_bytes = ptyterm_send_message(client_fd, PTYTERM_MESSAGE_RECV_RESPONSE,
                                         response,

--- a/src/test-ptyterm-help.sh
+++ b/src/test-ptyterm-help.sh
@@ -96,6 +96,12 @@ printf '%s\n' "$out" | grep -q -- "--recv" || {
   exit 1
 }
 
+printf '%s\n' "$out" | grep -q -- "--peek" || {
+  echo "ptyterm -h: expected peek option in output" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+}
+
 printf '%s\n' "$out" | grep -q -- "--rows=N" || {
   echo "ptyterm -h: expected rows option in output" >&2
   printf '%s\n' "$out" >&2

--- a/src/test-ptyterm-recv-peek-errors.sh
+++ b/src/test-ptyterm-recv-peek-errors.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+if ./ptyterm --peek --session=1 >out.txt 2>err.txt; then
+  echo "ptyterm --peek without --recv: expected failure" >&2
+  exit 1
+fi
+
+grep -q -- '--peek requires --recv' err.txt || {
+  echo "ptyterm --peek without --recv: expected validation error" >&2
+  cat err.txt >&2
+  exit 1
+}
+
+grep -q -- '--help-format=yaml' err.txt || {
+  echo "ptyterm --peek without --recv: expected structured help discovery hint" >&2
+  cat err.txt >&2
+  exit 1
+}
+
+rm -f out.txt err.txt

--- a/src/test-ptyterm-send-recv.sh
+++ b/src/test-ptyterm-send-recv.sh
@@ -7,6 +7,8 @@ daemon_pid=
 expected=$tmpdir/expected.bin
 received=$tmpdir/received.bin
 received2=$tmpdir/received2.bin
+peeked=$tmpdir/peeked.bin
+received3=$tmpdir/received3.bin
 
 cleanup() {
   if [ -n "${daemon_pid}" ] && kill -0 "$daemon_pid" 2>/dev/null; then
@@ -78,6 +80,50 @@ cmp "$expected" "$received" || {
 grep -q 'recv ' "$tmpdir/recv.err" || {
   echo "ptyterm --recv: expected status output on stderr" >&2
   cat "$tmpdir/recv.err" >&2 || true
+  exit 1
+}
+
+send_out=$(./ptyterm --send='ABC' --session=1 --socket="$sock" 2>&1) || {
+  echo "ptyterm second --send: expected success" >&2
+  printf '%s\n' "$send_out" >&2
+  exit 1
+}
+
+./ptyterm --recv --peek --recv-size=3 --session=1 --socket="$sock" >"$peeked" 2>"$tmpdir/peek.err" || {
+  echo "ptyterm --recv --peek: expected success" >&2
+  cat "$tmpdir/peek.err" >&2 || true
+  exit 1
+}
+
+cmp "$expected" "$peeked" || {
+  echo "ptyterm --recv --peek: expected exact byte payload" >&2
+  od -An -tx1 "$peeked" >&2 || true
+  cat "$tmpdir/peek.err" >&2 || true
+  exit 1
+}
+
+grep -q 'next-offset=3' "$tmpdir/peek.err" || {
+  echo "ptyterm --recv --peek: expected unchanged recv cursor" >&2
+  cat "$tmpdir/peek.err" >&2 || true
+  exit 1
+}
+
+./ptyterm --recv --recv-size=3 --session=1 --socket="$sock" >"$received3" 2>"$tmpdir/recv3.err" || {
+  echo "ptyterm recv after peek: expected success" >&2
+  cat "$tmpdir/recv3.err" >&2 || true
+  exit 1
+}
+
+cmp "$expected" "$received3" || {
+  echo "ptyterm recv after peek: expected same byte payload" >&2
+  od -An -tx1 "$received3" >&2 || true
+  cat "$tmpdir/recv3.err" >&2 || true
+  exit 1
+}
+
+grep -q 'next-offset=6' "$tmpdir/recv3.err" || {
+  echo "ptyterm recv after peek: expected advanced recv cursor" >&2
+  cat "$tmpdir/recv3.err" >&2 || true
   exit 1
 }
 


### PR DESCRIPTION
## Summary
- add `--peek` for `ptyterm --recv` so callers can inspect buffered output without advancing the recv cursor
- extend the recv request protocol with a flags field and keep cursor advancement disabled only for peek mode
- add help and regression coverage for peek behavior and invalid CLI usage

## Testing
- `make check`
- `make distcheck`

Closes #16