### PR TITLE
Add help output to biopen

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,6 +27,7 @@ TESTS = \
 	test-ptyterm-resize.sh \
 	test-ptyterm-send-recv.sh \
 	test-ptywrap-help.sh \
+	test-biopen-help.sh \
 	test-pbuf-help.sh \
 	test-pbuf-copy.sh
 

--- a/src/biopen.c
+++ b/src/biopen.c
@@ -1,3 +1,9 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#define PACKAGE_STRING "biopen"
+#endif
+
 #include <errno.h>
 #include <fcntl.h>
 #include <locale.h>
@@ -19,6 +25,31 @@ int main(int argc, char *const argv[]) {
   char *filename = NULL;
 
   setlocale(LC_ALL, "");
+  if (argc == 2 &&
+      (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0)) {
+    printf("%s\n", PACKAGE_STRING);
+    printf("\n");
+    printf("Usage:\n");
+    printf("  %s\n", argv[0]);
+    printf("  %s PATH\n", argv[0]);
+    printf("  %s -h\n", argv[0]);
+    printf("  %s -V\n", argv[0]);
+    printf("\n");
+    printf("Options:\n");
+    printf("  -h, --help    : print this usage and exit\n");
+    printf("  -V, --version : print version and exit\n");
+    printf("\n");
+    printf("Notes:\n");
+    printf("  Without PATH, biopen uses the controlling terminal from stdin.\n");
+    printf("  PATH must name a character device or socket opened read-write.\n");
+    exit(EXIT_SUCCESS);
+  }
+  if (argc == 2 &&
+      (strcmp(argv[1], "-V") == 0 || strcmp(argv[1], "--version") == 0)) {
+    printf("%s\n", PACKAGE_STRING);
+    exit(EXIT_SUCCESS);
+  }
+
   switch (argc) {
   case 1:
     filename = ttyname(STDIN_FILENO);

--- a/src/test-biopen-help.sh
+++ b/src/test-biopen-help.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+out=$(./biopen -h 2>&1) || {
+  echo "biopen -h: expected exit 0" >&2
+  exit 1
+}
+
+printf '%s\n' "$out" | grep -q "Usage" || {
+  echo "biopen -h: expected Usage in output" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+}
+
+printf '%s\n' "$out" | grep -q "PATH must name a character device or socket" || {
+  echo "biopen -h: expected path note in output" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+}
+
+version_out=$(./biopen -V 2>&1) || {
+  echo "biopen -V: expected exit 0" >&2
+  exit 1
+}
+
+printf '%s\n' "$version_out" | grep -q "^ptyterm 0\.10\.0$" || {
+  echo "biopen -V: expected PACKAGE_STRING output" >&2
+  printf '%s\n' "$version_out" >&2
+  exit 1
+}


### PR DESCRIPTION
## Summary
- add minimal `--help` and `--version` handling to `biopen`
- document the supported positional `[PATH]` interface in the built-in help text
- add `test-biopen-help.sh` and include it in `make check`

## Testing
- `make -C src check TESTS='test-biopen-help.sh'`
- `make check`
- `make distcheck`

Closes #20
