### PR TITLE
recv: default to escaped output on TTY stdout

### DIFF
--- a/docs/ptyterm-session-design.md
+++ b/docs/ptyterm-session-design.md
@@ -224,14 +224,54 @@ Rules:
 
 This mirrors the recv model: one verb option selects the operation, additional named options refine the behavior.
 
+### Recv output format shape
+
+Recv rendering should stay separate from `--status-format`.
+
+- `--status-format` remains the rendering control for status-oriented operations such as `list` and `buffer-info`, and for recv status lines when recv uses a text-oriented output format.
+- `--recv-format` defines how recv payload is rendered on standard output.
+- The default recv format should depend on whether standard output is a TTY: use `escaped` for terminal output and `raw` otherwise.
+
+Recommended recv forms:
+
+```sh
+ptyterm --recv --session=ID [--recv-size=BYTES] [--recv-timeout=DURATION] [--recv-lines=N] [--recv-format=escaped|raw|json]
+```
+
+Rules for recv output formats:
+
+- When `--recv-format` is omitted, select `escaped` if `isatty(STDOUT_FILENO)` is true and `raw` otherwise.
+- Escaped mode should reuse the same escape vocabulary already accepted by `--send=DATA` so control bytes such as `\n`, `\r`, `\t`, `\0`, and `\x1e` round-trip predictably.
+- Escaped mode should leave ordinary printable bytes readable, escape control bytes and backslashes, and append one terminating newline after each successful non-empty recv result so the next shell prompt starts on its own line.
+- `--recv-format=raw` preserves the exact-byte scripting contract by writing the received bytes unchanged to standard output.
+- `--recv-format=json` writes one structured envelope to standard output containing the payload plus the same logical recv metadata that is otherwise summarized on standard error.
+- The JSON envelope should carry payload bytes in a binary-safe way rather than assuming UTF-8 text.
+- This keeps interactive terminal use readable without making redirected or piped recv calls silently lose byte-exact behavior.
+
+Examples:
+
+```sh
+ptyterm --recv --session=7
+ptyterm --recv --session=7 --recv-format=raw >recv.bin
+ptyterm --recv --session=7 --recv-format=json
+```
+
+The structured recv envelope should include the session identity, whether the read was `peek`, the stop reason, the next offset, and the payload bytes.
+
+Send does not need a matching `--send-format` option in the first version.
+
+- `--send=DATA` already accepts escape decoding at the CLI boundary.
+- The escaped recv form should reuse that same byte notation so users can copy escaped output back into `--send` when needed.
+- If a later release needs bulk structured input such as `--send-file`, it can be designed independently from recv rendering.
+
 ### Status output shape
 
 All daemon-backed status-producing operations should share the same output convention.
 
 - Human-readable text by default.
 - Stable `key=value` lines when `--status-format=kv` is selected.
-- Raw payload bytes, when any exist, go to standard output.
-- Status metadata goes to standard error.
+- For `--recv-format=escaped|raw`, payload output goes to standard output and recv status metadata goes to standard error.
+- For `--recv-format=json`, the stdout contract is defined by the selected payload format and standard error should be reserved for fatal diagnostics.
 
 This should apply consistently to `send`, `recv`, `list`, and `buffer-info`.
 
@@ -293,7 +333,7 @@ Usage:
   ptyterm --detach --session=ID
   ptyterm --list [--session=ID]
   ptyterm --send=DATA --session=ID [--send-policy=block|truncate]
-  ptyterm --recv --session=ID [--recv-size=BYTES] [--recv-timeout=DURATION] [--recv-lines=N]
+  ptyterm --recv --session=ID [--recv-size=BYTES] [--recv-timeout=DURATION] [--recv-lines=N] [--recv-format=escaped|raw|json]
   ptyterm --buffer-info --session=ID
 
 Default mode:
@@ -328,6 +368,8 @@ Management operation options:
   --recv-size=BYTES          Maximum bytes to return from recv
   --recv-timeout=DURATION    Maximum recv wait time
   --recv-lines=N             Maximum lines to return from recv
+  --recv-format=escaped|raw|json
+                             Recv payload contract
 
 Compatibility aliases:
   -A --attach
@@ -345,8 +387,10 @@ Compatibility aliases:
 Notes:
   Exactly one management operation may be selected per invocation.
   Management operations cannot be combined with CMD execution.
-  recv writes payload bytes to stdout and status metadata to stderr.
-  Status format 'kv' prints one key=value pair per line.
+  recv defaults to escaped stdout rendering when stdout is a TTY, and raw bytes otherwise.
+  Escaped recv appends a terminating newline so the next shell prompt is distinct.
+  Structured recv output carries both payload and recv metadata on stdout.
+  Status format 'kv' prints one key=value pair per line for escaped or raw recv status output.
 ```
 
 #### Draft `ptytermd --help`
@@ -814,7 +858,7 @@ This mirrors the `send` side closely:
 
 #### recv status formatting
 
-Like `send`, `recv` should use text by default and stable key-value output when `--status-format=kv` is selected.
+For `--recv-format=escaped|raw`, `recv` should use text by default and stable key-value output when `--status-format=kv` is selected.
 
 Example text output:
 
@@ -834,7 +878,13 @@ truncated=0
 reason=size_reached
 ```
 
-This makes `recv` scriptable using the same parsing strategy as `send`.
+This makes escaped and raw `recv` scriptable using the same parsing strategy as `send`, while letting non-interactive stdout keep raw bytes by default.
+
+For `--recv-format=json`, the selected payload envelope becomes the complete stdout contract for successful responses.
+
+- Structured recv output should include both payload bytes and recv metadata together.
+- Standard error should be reserved for fatal diagnostics.
+- `--status-format` should be rejected together with structured recv formats to avoid two competing metadata channels.
 
 ## recv spec
 
@@ -860,15 +910,18 @@ Defaults:
 - `timeout=1s`
 - `lines=0` for unlimited lines
 
-`recv` returns both payload bytes and status metadata. In text mode, the payload is written to standard output and status text goes to standard error. In `kv` mode, payload handling needs a deterministic split.
+`recv` returns both payload bytes and status metadata. In escaped and raw modes, the payload is written to standard output and status text goes to standard error. In structured mode, both are serialized together on standard output.
 
 Recommended first-version rule:
 
-- `recv` payload always goes to standard output.
-- `--status-format=text` prints status to standard error.
-- `--status-format=kv` also prints status to standard error in `key=value` form.
+- If `--recv-format` is omitted, `recv` chooses `escaped` for TTY stdout and `raw` otherwise.
+- `--recv-format=escaped` writes escaped payload text to standard output and appends one terminating newline after each successful non-empty recv result.
+- `--recv-format=raw` writes payload bytes unchanged to standard output.
+- `--status-format=text` prints escaped or raw recv status to standard error.
+- `--status-format=kv` prints escaped or raw recv status to standard error in `key=value` form.
+- `--recv-format=json` writes a single structured response to standard output and rejects `--status-format`.
 
-This avoids mixing raw session bytes with parseable status lines on the same stream.
+This avoids mixing raw session bytes with parseable status lines on the same stream while still allowing a single-stream structured contract for automation.
 
 Parsing rules:
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,6 +13,7 @@ TESTS = \
 	test-ptyterm-help.sh \
 	test-ptyterm-help-errors.sh \
 	test-ptyterm-help-format.sh \
+	test-ptyterm-recv-format.sh \
 	test-ptyterm-recv-peek-errors.sh \
 	test-ptyterm-recv-wait.sh \
 	test-ptyterm-daemon-lifecycle.sh \

--- a/src/ptyterm.c
+++ b/src/ptyterm.c
@@ -75,6 +75,12 @@ static void print_recv_status_line(uint32_t returned_bytes, uint64_t start_offse
                                    uint64_t end_offset, uint64_t next_recv_offset,
                                    int truncated, const char *reason);
 
+enum ptyterm_recv_format {
+  PTYTERM_RECV_FORMAT_AUTO = 0,
+  PTYTERM_RECV_FORMAT_RAW,
+  PTYTERM_RECV_FORMAT_ESCAPED,
+};
+
 static int set_nonblocking(int fd) {
   int flags;
 
@@ -99,6 +105,14 @@ static int parse_help_format(const char *value) {
     return PTYTERM_HELP_FORMAT_TEXT;
   if (strcmp(value, "yaml") == 0)
     return PTYTERM_HELP_FORMAT_YAML;
+  return -1;
+}
+
+static int parse_recv_format(const char *value) {
+  if (strcmp(value, "raw") == 0)
+    return PTYTERM_RECV_FORMAT_RAW;
+  if (strcmp(value, "escaped") == 0)
+    return PTYTERM_RECV_FORMAT_ESCAPED;
   return -1;
 }
 
@@ -198,6 +212,7 @@ static void print_text_help(FILE *out, const char *program_name) {
   fprintf(out, "  -B, --buffer-info   : show buffer state for one session\n");
   fprintf(out, "      --send=DATA     : send decoded bytes to one session\n");
   fprintf(out, "      --recv          : receive buffered output from one session\n");
+  fprintf(out, "      --recv-format=raw|escaped : select recv payload rendering (default: escaped on TTY stdout, raw otherwise)\n");
   fprintf(out, "      --recv-size=N   : maximum bytes returned by --recv\n");
   fprintf(out, "      --recv-timeout=DURATION : wait up to DURATION (ms|s) for recv\n");
   fprintf(out, "      --recv-until=STRING : wait until unread output contains STRING\n");
@@ -318,6 +333,12 @@ static void print_yaml_help(FILE *out, const char *program_name) {
   fprintf(out, "      argument: none\n");
   fprintf(out, "      requires: [--session]\n");
   fprintf(out, "      description: Receive buffered output from one session.\n");
+  fprintf(out, "    - long: --recv-format\n");
+  fprintf(out, "      short: null\n");
+  fprintf(out, "      argument: raw|escaped\n");
+  fprintf(out, "      requires: [--recv]\n");
+  fprintf(out, "      default: escaped on TTY stdout, raw otherwise\n");
+  fprintf(out, "      description: Select exact-byte or terminal-safe recv payload rendering.\n");
   fprintf(out, "    - long: --peek\n");
   fprintf(out, "      short: null\n");
   fprintf(out, "      argument: none\n");
@@ -895,6 +916,78 @@ static size_t decode_send_data(const char *input, char *output, size_t output_si
   return out_offset;
 }
 
+static int write_recv_payload_raw(const char *data, uint32_t size) {
+  if (size == 0)
+    return EXIT_SUCCESS;
+  if (fwrite(data, 1, size, stdout) != size) {
+    perror("fwrite");
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+static int write_recv_payload_escaped(const char *data, uint32_t size) {
+  uint32_t offset;
+
+  for (offset = 0; offset < size; ++offset) {
+    unsigned char byte;
+
+    byte = (unsigned char)data[offset];
+    switch (byte) {
+    case '\\':
+      if (fputs("\\\\", stdout) == EOF) {
+        perror("fputs");
+        return EXIT_FAILURE;
+      }
+      break;
+    case '\n':
+      if (fputs("\\n", stdout) == EOF) {
+        perror("fputs");
+        return EXIT_FAILURE;
+      }
+      break;
+    case '\r':
+      if (fputs("\\r", stdout) == EOF) {
+        perror("fputs");
+        return EXIT_FAILURE;
+      }
+      break;
+    case '\t':
+      if (fputs("\\t", stdout) == EOF) {
+        perror("fputs");
+        return EXIT_FAILURE;
+      }
+      break;
+    case 0x1b:
+      if (fputs("\\e", stdout) == EOF) {
+        perror("fputs");
+        return EXIT_FAILURE;
+      }
+      break;
+    default:
+      if (byte >= 0x20 && byte <= 0x7e) {
+        if (fputc(byte, stdout) == EOF) {
+          perror("fputc");
+          return EXIT_FAILURE;
+        }
+      } else {
+        if (fprintf(stdout, "\\x%02x", byte) < 0) {
+          perror("fprintf");
+          return EXIT_FAILURE;
+        }
+      }
+      break;
+    }
+  }
+
+  if (size > 0 && fputc('\n', stdout) == EOF) {
+    perror("fputc");
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}
+
 static int run_send_client(const char *socket_path, int session_id,
                            const char *send_data) {
   char default_socket_path[PTYTERM_SOCKET_PATH_MAX];
@@ -1019,14 +1112,17 @@ static int request_recv_client(const char *socket_path, int session_id,
 }
 
 static int print_recv_payload_and_status(
-  const struct ptyterm_recv_response *response, const char *reason_override) {
+  const struct ptyterm_recv_response *response, const char *reason_override,
+  int recv_format) {
   const char *data;
 
   data = (const char *)(response + 1);
-  if (response->returned_bytes > 0 &&
-      fwrite(data, 1, response->returned_bytes, stdout) != response->returned_bytes) {
-    perror("fwrite");
-    return EXIT_FAILURE;
+  if (recv_format == PTYTERM_RECV_FORMAT_ESCAPED) {
+    if (write_recv_payload_escaped(data, response->returned_bytes) != EXIT_SUCCESS)
+      return EXIT_FAILURE;
+  } else {
+    if (write_recv_payload_raw(data, response->returned_bytes) != EXIT_SUCCESS)
+      return EXIT_FAILURE;
   }
 
   print_recv_status_line(response->returned_bytes, response->start_offset,
@@ -1040,16 +1136,20 @@ static int print_recv_payload_and_status(
 static int run_recv_client(const char *socket_path, int session_id,
                            uint32_t recv_size, int recv_peek,
                            uint64_t recv_timeout_ms,
-                           const char *recv_until) {
+                           const char *recv_until, int recv_format) {
   char payload[8192];
   const struct ptyterm_recv_response *response;
   uint64_t deadline_ms = 0;
   size_t until_size;
 
+  if (recv_format == PTYTERM_RECV_FORMAT_AUTO)
+    recv_format = isatty(STDOUT_FILENO) ? PTYTERM_RECV_FORMAT_ESCAPED
+                                        : PTYTERM_RECV_FORMAT_RAW;
+
   if (recv_until == NULL && recv_timeout_ms == 0)
     return request_recv_client(socket_path, session_id, recv_size, recv_peek,
                                payload, sizeof(payload), &response) == EXIT_SUCCESS
-               ? print_recv_payload_and_status(response, NULL)
+               ? print_recv_payload_and_status(response, NULL, recv_format)
                : EXIT_FAILURE;
 
   until_size = recv_until == NULL ? 0 : strlen(recv_until);
@@ -1088,7 +1188,7 @@ static int run_recv_client(const char *socket_path, int session_id,
           EXIT_SUCCESS)
         return EXIT_FAILURE;
       return print_recv_payload_and_status(
-          response, recv_until == NULL ? NULL : "match_reached");
+          response, recv_until == NULL ? NULL : "match_reached", recv_format);
     }
 
     if (recv_until != NULL && response->returned_bytes == recv_size) {
@@ -1730,6 +1830,7 @@ int main(int argc, char *const argv[]) {
   int help_format = PTYTERM_HELP_FORMAT_TEXT;
   int list_requested = 0;
   int recv_peek = 0;
+  int recv_format = PTYTERM_RECV_FORMAT_AUTO;
   const char *recv_until = NULL;
   uint64_t recv_timeout_ms = 0;
   int resize_requested = 0;
@@ -1750,6 +1851,7 @@ int main(int argc, char *const argv[]) {
     enum {
       OPT_SEND = 1000,
       OPT_RECV,
+      OPT_RECV_FORMAT,
       OPT_RECV_SIZE,
       OPT_RECV_TIMEOUT,
       OPT_RECV_UNTIL,
@@ -1774,6 +1876,7 @@ int main(int argc, char *const argv[]) {
                        {"resize", no_argument, NULL, 'R'},
                        {"send", required_argument, NULL, OPT_SEND},
                        {"recv", no_argument, NULL, OPT_RECV},
+                       {"recv-format", required_argument, NULL, OPT_RECV_FORMAT},
                        {"recv-size", required_argument, NULL, OPT_RECV_SIZE},
                        {"recv-timeout", required_argument, NULL, OPT_RECV_TIMEOUT},
                        {"recv-until", required_argument, NULL, OPT_RECV_UNTIL},
@@ -1840,6 +1943,11 @@ int main(int argc, char *const argv[]) {
       break;
     case OPT_RECV:
       recv_requested = 1;
+      break;
+    case OPT_RECV_FORMAT:
+      recv_format = parse_recv_format(optarg);
+      if (recv_format < 0)
+        return usage_error(argv[0], "unsupported recv-format: %s", optarg);
       break;
     case OPT_PEEK:
       recv_peek = 1;
@@ -1913,6 +2021,8 @@ int main(int argc, char *const argv[]) {
 
   if (recv_peek && !recv_requested)
     return usage_error(argv[0], "--peek requires --recv");
+  if (recv_format != PTYTERM_RECV_FORMAT_AUTO && !recv_requested)
+    return usage_error(argv[0], "--recv-format requires --recv");
   if ((recv_timeout_ms != 0 || recv_until != NULL) && !recv_requested)
     return usage_error(argv[0], "recv wait options require --recv");
 
@@ -1976,7 +2086,7 @@ int main(int argc, char *const argv[]) {
       return run_send_client(socket_path, session_id, send_data);
     if (recv_requested)
       return run_recv_client(socket_path, session_id, recv_size, recv_peek,
-                             recv_timeout_ms, recv_until);
+                             recv_timeout_ms, recv_until, recv_format);
     return run_buffer_info_client(socket_path, session_id, status_format);
   }
 

--- a/src/test-ptyterm-help-format.sh
+++ b/src/test-ptyterm-help-format.sh
@@ -42,3 +42,9 @@ printf '%s\n' "$out" | grep -q 'long: --create' || {
   printf '%s\n' "$out" >&2
   exit 1
 }
+
+printf '%s\n' "$out" | grep -q 'long: --recv-format' || {
+  echo "ptyterm --help-format=yaml: expected recv-format option entry" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+}

--- a/src/test-ptyterm-help.sh
+++ b/src/test-ptyterm-help.sh
@@ -96,6 +96,12 @@ printf '%s\n' "$out" | grep -q -- "--recv" || {
   exit 1
 }
 
+printf '%s\n' "$out" | grep -q -- "--recv-format=raw|escaped" || {
+  echo "ptyterm -h: expected recv-format option in output" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+}
+
 printf '%s\n' "$out" | grep -q -- "--recv-timeout=DURATION" || {
   echo "ptyterm -h: expected recv-timeout option in output" >&2
   printf '%s\n' "$out" >&2

--- a/src/test-ptyterm-recv-format.sh
+++ b/src/test-ptyterm-recv-format.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -eu
+
+command -v script >/dev/null 2>&1 || exit 77
+
+tmpdir=${TMPDIR:-/tmp}/ptyterm-recv-format.$$
+sock=$tmpdir/daemon.sock
+daemon_pid=
+
+cleanup() {
+  if [ -n "${daemon_pid}" ] && kill -0 "$daemon_pid" 2>/dev/null; then
+    kill "$daemon_pid" 2>/dev/null || true
+    wait "$daemon_pid" 2>/dev/null || true
+  fi
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$tmpdir"
+./ptytermd --socket="$sock" >"$tmpdir/daemon.out" 2>"$tmpdir/daemon.err" &
+daemon_pid=$!
+
+i=0
+while [ ! -e "$sock" ]; do
+  i=$((i + 1))
+  if [ "$i" -ge 10 ]; then
+    echo "ptytermd did not create socket" >&2
+    cat "$tmpdir/daemon.err" >&2 || true
+    exit 1
+  fi
+  sleep 1
+done
+
+create_out=$(./ptyterm --create --socket="$sock" /bin/sh -c 'stty raw -echo; exec cat' 2>&1) || {
+  echo "ptyterm --create for recv-format: expected success" >&2
+  printf '%s\n' "$create_out" >&2
+  exit 1
+}
+
+printf '%s\n' "$create_out" | grep -q '^session_id=1$' || {
+  echo "ptyterm --create for recv-format: expected session id 1" >&2
+  printf '%s\n' "$create_out" >&2
+  exit 1
+}
+
+./ptyterm --send='A\n\\\e' --session=1 --socket="$sock" >/dev/null 2>"$tmpdir/send.err" || {
+  echo "ptyterm --send for recv-format: expected success" >&2
+  cat "$tmpdir/send.err" >&2 || true
+  exit 1
+}
+
+script -q -c "exec ./ptyterm --recv --recv-size=4 --session=1 --socket='$sock' 2>'$tmpdir/recv.err'" /dev/null >"$tmpdir/tty.out" 2>"$tmpdir/tty.err" || {
+  echo "ptyterm --recv on tty: expected success" >&2
+  cat "$tmpdir/tty.out" >&2 || true
+  cat "$tmpdir/recv.err" >&2 || true
+  cat "$tmpdir/tty.err" >&2 || true
+  exit 1
+}
+
+tr -d '\r' <"$tmpdir/tty.out" >"$tmpdir/tty.norm"
+printf '%s\n' 'A\n\\\e' >"$tmpdir/expected.out"
+
+cmp "$tmpdir/expected.out" "$tmpdir/tty.norm" || {
+  echo "ptyterm --recv on tty: expected escaped payload plus newline" >&2
+  od -An -tx1 "$tmpdir/tty.norm" >&2 || true
+  od -An -tx1 "$tmpdir/expected.out" >&2 || true
+  cat "$tmpdir/recv.err" >&2 || true
+  cat "$tmpdir/tty.err" >&2 || true
+  exit 1
+}
+
+grep -q 'recv 4 bytes' "$tmpdir/recv.err" || {
+  echo "ptyterm --recv on tty: expected recv status output on stderr" >&2
+  cat "$tmpdir/recv.err" >&2 || true
+  cat "$tmpdir/tty.err" >&2 || true
+  exit 1
+}


### PR DESCRIPTION
- Default recv output is escaped on TTY stdout and raw otherwise.
- Adds `--recv-format=raw|escaped`.
- Updates help/docs.
- Adds a TTY recv test.
- Full `make check` passed.
- Closes #23.
