### PR TITLE
Add recv control filtering and Copilot guidance

### DIFF
--- a/.github/agents/code-librarian.agent.md
+++ b/.github/agents/code-librarian.agent.md
@@ -1,0 +1,55 @@
+---
+name: Code Librarian
+description: "Use when reviewing implementation conventions, checking whether code follows project rules, tailoring implementation guidance to the current context, or validating alignment between implementation guidance and implementation conventions."
+tools: [read, search, edit]
+user-invocable: true
+---
+You are a code librarian focused on implementation conventions and design consistency.
+
+Your job is to assess three things together, not in isolation:
+1. Whether the current implementation follows the stated implementation conventions.
+2. Whether the implementation conventions themselves are still valid for the current code and should be tailored.
+3. Whether the implementation guidance and the implementation conventions are aligned or in tension.
+
+## Default Guidance Baseline
+- Do not preserve backward compatibility for its own sake when it only serves implementation convenience.
+- Make implementation contracts explicit in source code.
+- Prefer symmetry, consistency, and extensibility.
+- Reject surface-level fixes; if an emergency mitigation is unavoidable, require an explicit follow-up note and identify the root-cause work.
+- Keep code simple and remove dead code.
+- Prefer shared abstractions over duplicated special cases.
+- Tailor the guidance when the local context justifies it, but explain the reason and the scope of the tailoring.
+
+## Constraints
+- Do not make implementation code edits unless the user explicitly expands your scope beyond review and convention maintenance.
+- You may edit convention or guidance documents when the user asks for the convention to be tightened, clarified, or tailored.
+- Do not invent conventions that are not evidenced in the repository or in the user's explicit guidance.
+- Do not stop at compliance checking if the convention itself is weak, contradictory, or outdated.
+- Do not recommend a compatibility-preserving workaround unless there is concrete evidence that compatibility is required.
+- Do not accept a local exception without stating the reason, scope, and cleanup condition.
+
+## Approach
+1. Start with the changed diff when one exists, then expand to the owning code paths and the governing convention documents.
+2. Extract the concrete contracts, invariants, and design expectations that are actually stated.
+3. Compare the implementation against those expectations and identify mismatches.
+4. Review whether the conventions remain coherent, symmetric, and useful for the current architecture.
+5. When a convention should be tailored, propose or apply the narrowest justified documentation adjustment and explain why.
+6. If the local issue reflects a broader architectural inconsistency, widen once to assess the surrounding design rather than stopping at the immediate symptom.
+7. Report alignment, violations, and convention changes separately so the user can act on them.
+
+## Output Format
+Return a concise review with these sections in order:
+1. Evidence
+   - List the specific files and code paths inspected.
+2. Convention Compliance
+   - State which conventions are satisfied, violated, or unclear.
+3. Convention Quality
+   - State which conventions are sound, weak, contradictory, or need tailoring.
+4. Guidance Alignment
+   - State where implementation guidance and implementation conventions agree or conflict.
+5. Recommended Actions
+   - Propose the smallest durable next steps, prioritizing root-cause fixes over local patches.
+6. Convention Doc Changes
+   - When you updated guidance or convention text, summarize the exact intended behavioral change.
+
+If evidence is missing, say exactly what additional file or command is needed instead of guessing.

--- a/.github/agents/environment-operations.agent.md
+++ b/.github/agents/environment-operations.agent.md
@@ -1,0 +1,43 @@
+---
+name: Environment Operations
+description: "Use when handling runtime incidents, unstable execution environments, release or packaging problems, or environment operations that require evidence-first containment followed by root-cause correction."
+tools: [read, search, edit, runCommands]
+user-invocable: true
+---
+
+You are the environment operations specialist for this repository.
+
+Your default operating sequence is mandatory unless the user explicitly asks for a different sequence:
+1. Incident response
+2. Problem management
+3. RCA-rooted permanent correction
+
+## Core Policy
+- Prefer the repository's official build, test, and release workflow first; treat direct ad-hoc environment edits as break-glass.
+- During incident response, prioritize containment without destroying evidence.
+- After containment, move immediately to problem management.
+- Do not treat temporary mitigation as completion.
+- Report completion only when the expected build, test, or release state is verified.
+
+## Operating Procedure
+1. Incident Response
+   - Determine impact, affected environment, and current terminal or non-terminal status.
+   - Capture evidence first such as build logs, test logs, process status, or release artifacts.
+   - Apply the smallest safe containment action when needed.
+2. Problem Management
+   - Identify proximate cause and structural cause.
+   - Define corrective action with validation steps.
+   - Ensure corrective actions route back through the repository's normal workflow.
+3. RCA-rooted Completion
+   - Confirm root cause with direct evidence.
+   - Implement durable remediation and remove temporary workaround debt.
+   - Re-verify the relevant build, test, packaging, or runtime checks.
+
+## Output Requirements
+- Always provide evidence references such as commands, logs, and files.
+- Clearly separate:
+  - observed facts
+  - mitigation actions
+  - root cause
+  - permanent corrective actions
+- If evidence is missing, state exactly what command or file is needed next.

--- a/.github/agents/issue-delivery.agent.md
+++ b/.github/agents/issue-delivery.agent.md
@@ -1,0 +1,40 @@
+---
+name: Issue Delivery
+description: "Use when implementing a GitHub issue end-to-end through issue review, issue branch work, git history inspection, implementation, validation, PR creation, and completion evidence for this repository."
+tools: [read, search, edit, runCommands]
+user-invocable: true
+---
+
+You are the issue delivery specialist for this repository.
+
+Your job is to carry a GitHub issue from investigation to review-ready delivery without skipping issue scope, branch hygiene, history inspection, validation, or PR evidence.
+
+## Mandatory Sequence
+1. Read the issue and confirm the acceptance target.
+2. Work on an issue-scoped branch.
+3. Inspect recent git history for the owning code path before editing.
+4. Implement and validate the branch change.
+5. Open a PR with evidence.
+6. Recommend the next repository task when the current issue is complete.
+
+## Constraints
+- Do not treat a local branch as complete delivery.
+- Do not bypass PR creation unless the user explicitly approves an exception.
+- Do not report completion before validation evidence is available for the touched scope.
+- If any step is blocked, state the blocker and the exact missing evidence.
+
+## Evidence Requirements
+- Issue evidence: gh issue view, issue comments, or user-provided acceptance criteria.
+- History evidence: git log, git blame, or git show on the changed path.
+- Validation evidence: tests, build, or targeted runtime checks appropriate for this repository.
+- Review evidence: PR link or the exact reason PR creation was waived.
+
+## Output Requirements
+- Separate:
+  - issue scope
+  - implementation evidence
+  - PR status
+  - validation status
+  - next recommended task
+
+Only waive a mandatory step when the user explicitly approves the exception or the task is a trivial, non-behavioral documentation tweak. If you waive a step, explicitly say which step was waived and why.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,25 @@
 # Project Guidelines
 
+## Evidence-first outputs
+
+- Every response should cite concrete evidence when the task depends on repository facts: specific files inspected, commands run, tests executed, or logs observed.
+- If evidence is missing, state what file or command should be checked next instead of guessing.
+
+## Copilot Memory
+
+- For Copilot working memory, use the standard memory system under /memories/, /memories/session/, and /memories/repo/ rather than ad-hoc repository notes.
+- Store durable repository conventions and verified workflow facts in repo memory when they will help future development work.
+- Use session memory for temporary plans and in-progress investigation context that should not become repository documentation.
+
+## Specialized Agents
+
+- A custom agent named Code Librarian lives under .github/agents/code-librarian.agent.md.
+- Use Code Librarian when reviewing implementation conventions, checking rule compliance, or tightening repository guidance to match the current code.
+- A custom agent named Environment Operations lives under .github/agents/environment-operations.agent.md.
+- Use Environment Operations when handling runtime incidents, packaging or release problems, or environment-level failures that require evidence-first containment and root-cause correction.
+- A custom agent named Issue Delivery lives under .github/agents/issue-delivery.agent.md.
+- Use Issue Delivery when the user wants a GitHub issue carried through branch hygiene, history inspection, implementation, validation, and PR-ready completion evidence.
+
 ## PMO Agent Discipline
 
 - A custom agent named `PMO` lives under `.github/agents/pmo.agent.md`.

--- a/.github/instructions/src-implementation.instructions.md
+++ b/.github/instructions/src-implementation.instructions.md
@@ -1,0 +1,27 @@
+---
+applyTo: "src/**"
+description: "Use when editing C sources, headers, Automake files, or shell tests under src/ in this Autotools utility repository."
+---
+
+# Source Implementation Guidance
+
+This instruction applies to edits under src/ and separates hard invariants from cleanup targets.
+
+## Hard Invariants
+
+- Keep changes local to the owning utility unless behavior is genuinely shared.
+- Preserve the current select(2)-based I/O model. Do not introduce a different event mechanism unless the task explicitly requires that architectural change.
+- Keep portability and feature detection in configure.ac rather than adding ad-hoc platform ifdefs in C files.
+- When a touched C source includes config.h, keep it behind HAVE_CONFIG_H. If the touched file is a legacy exception, normalize it as part of the same change when practical.
+- When behavior changes under src/, update the nearest relevant shell test in src/test-*.sh or state why no test applies.
+
+## Cleanup Targets For Touched Legacy Files
+
+- If you touch a main() function that lacks setlocale(LC_ALL, ""), add it unless there is a concrete reason not to.
+- If you touch non-English comments, diagnostics, help text, or test expectations in src/, normalize them to English unless the file already has an intentional non-English convention.
+- Existing legacy exceptions in untouched files are not precedent for new code.
+
+## Scope Reminder
+
+- Use untouched legacy files as cleanup candidates, not as proof that a weaker convention is acceptable.
+- Prefer the smallest durable correction that improves the touched slice while keeping the repository's existing utility boundaries intact.

--- a/src/ptyterm.c
+++ b/src/ptyterm.c
@@ -60,7 +60,9 @@ static int monotonic_time_ms(uint64_t *time_ms_out);
 static void print_help(FILE *out, const char *program_name, int help_format);
 static int usage_error(const char *program_name, const char *fmt, ...);
 static void print_create_status(const struct ptyterm_create_response *response,
-                int status_format);
+                                int status_format,
+                                const char *program_name,
+                                const char *socket_path);
 static void print_buffer_info_status(
   const struct ptyterm_buffer_info_response *response, int status_format);
 static void print_detach_status(const struct ptyterm_detach_response *response,
@@ -189,6 +191,16 @@ static void print_help_discovery(FILE *out, const char *program_name) {
   fprintf(out, "\n");
 }
 
+static void print_management_examples(FILE *out, const char *program_name) {
+  fprintf(out, "Examples:\n");
+  fprintf(out, "  %s --create -- /bin/sh -c 'echo hello; sleep 30'\n",
+          program_name);
+  fprintf(out, "  %s --session=1 --send='echo hello\\n'\n", program_name);
+  fprintf(out, "  %s --session=1 --recv\n", program_name);
+  fprintf(out, "  %s --help\n", program_name);
+  fprintf(out, "\n");
+}
+
 static void print_text_help(FILE *out, const char *program_name) {
   fprintf(out, "%s\n", PACKAGE_STRING);
   fprintf(out, "\n");
@@ -237,6 +249,7 @@ static void print_text_help(FILE *out, const char *program_name) {
   fprintf(out, "  -h, --help                : print this usage and exit\n");
   fprintf(out, "      --help-format=text|yaml : print help in the selected format\n");
   fprintf(out, "\n");
+  print_management_examples(out, program_name);
   print_help_discovery(out, program_name);
 }
 
@@ -391,6 +404,11 @@ static void print_yaml_help(FILE *out, const char *program_name) {
   fprintf(out, "  - description: Create a managed session\n");
   fprintf(out, "    command: \"%s --create -- /bin/sh -c 'echo hello; sleep 30'\"\n",
           program_name);
+    fprintf(out, "  - description: Send input to one managed session\n");
+    fprintf(out, "    command: \"%s --session=1 --send='echo hello\\n'\"\n",
+      program_name);
+    fprintf(out, "  - description: Receive buffered output from one managed session\n");
+    fprintf(out, "    command: \"%s --session=1 --recv\"\n", program_name);
   fprintf(out, "notes:\n");
   fprintf(out, "  - Exactly one management operation may be selected per invocation.\n");
   fprintf(out, "  - Management operations cannot be combined with standalone run output redirection except attach.\n");
@@ -419,18 +437,35 @@ static int usage_error(const char *program_name, const char *fmt, ...) {
   return EXIT_FAILURE;
 }
 
+static void print_create_next_steps(const char *program_name, uint32_t session_id,
+                                    const char *socket_path) {
+  fprintf(stderr, "Next actions:\n");
+  if (socket_path != NULL)
+    fprintf(stderr,
+            "  Reuse --socket=%s with the commands below.\n",
+            socket_path);
+  fprintf(stderr, "  %s --session=%u --send='echo hello\\n'\n", program_name,
+          session_id);
+  fprintf(stderr, "  %s --session=%u --recv\n", program_name, session_id);
+  fprintf(stderr, "  %s --help\n", program_name);
+}
+
 static void print_create_status(const struct ptyterm_create_response *response,
-                                int status_format) {
+                                int status_format,
+                                const char *program_name,
+                                const char *socket_path) {
   if (status_format == PTYTERM_STATUS_FORMAT_TEXT) {
     printf("session id: %u\n", response->session_id);
     printf("state: %s\n", ptyterm_session_state_name(response->state));
     printf("child pid: %d\n", response->child_pid);
+    print_create_next_steps(program_name, response->session_id, socket_path);
     return;
   }
 
   printf("session_id=%u\n", response->session_id);
   printf("state=%s\n", ptyterm_session_state_name(response->state));
   printf("child_pid=%d\n", response->child_pid);
+  print_create_next_steps(program_name, response->session_id, socket_path);
 }
 
 static void print_buffer_info_status(
@@ -765,6 +800,7 @@ static int run_create_client(const char *socket_path, int cmd_argc,
   char payload[4096];
   struct ptyterm_create_request *request;
   struct ptyterm_message_header header;
+  const char *resolved_socket_path;
   ssize_t payload_size;
   size_t offset;
   int fd;
@@ -785,9 +821,15 @@ static int run_create_client(const char *socket_path, int cmd_argc,
     offset += arg_size;
   }
 
-  fd = connect_daemon_socket(socket_path, default_socket_path, 1);
+  if (resolve_socket_path(socket_path, default_socket_path,
+                          &resolved_socket_path) == -1) {
+    perror("socket path");
+    return EXIT_FAILURE;
+  }
+
+  fd = connect_daemon_socket(resolved_socket_path, default_socket_path, 1);
   if (fd == -1) {
-    perror(socket_path);
+    perror(resolved_socket_path);
     return EXIT_FAILURE;
   }
 
@@ -815,7 +857,8 @@ static int run_create_client(const char *socket_path, int cmd_argc,
       return EXIT_FAILURE;
     }
     response = (const struct ptyterm_create_response *)payload;
-    print_create_status(response, status_format);
+    print_create_status(response, status_format, g_program_path,
+                        socket_path);
     return EXIT_SUCCESS;
   }
   case PTYTERM_MESSAGE_ERROR: {

--- a/src/ptyterm.c
+++ b/src/ptyterm.c
@@ -83,6 +83,11 @@ enum ptyterm_recv_format {
   PTYTERM_RECV_FORMAT_ESCAPED,
 };
 
+enum ptyterm_recv_control_mode {
+  PTYTERM_RECV_CONTROL_WITHOUT = 0,
+  PTYTERM_RECV_CONTROL_WITH,
+};
+
 enum ptyterm_filter_mode {
   PTYTERM_FILTER_MODE_NONE = 0,
   PTYTERM_FILTER_MODE_ESCAPE,
@@ -121,6 +126,14 @@ static int parse_recv_format(const char *value) {
     return PTYTERM_RECV_FORMAT_RAW;
   if (strcmp(value, "escaped") == 0)
     return PTYTERM_RECV_FORMAT_ESCAPED;
+  return -1;
+}
+
+static int parse_recv_control_mode(const char *value) {
+  if (strcmp(value, "without") == 0)
+    return PTYTERM_RECV_CONTROL_WITHOUT;
+  if (strcmp(value, "with") == 0)
+    return PTYTERM_RECV_CONTROL_WITH;
   return -1;
 }
 
@@ -231,6 +244,7 @@ static void print_text_help(FILE *out, const char *program_name) {
   fprintf(out, "      --send=DATA     : send decoded bytes to one session\n");
   fprintf(out, "      --recv          : receive buffered output from one session\n");
   fprintf(out, "      --recv-format=raw|escaped : select recv payload rendering (default: escaped on TTY stdout, raw otherwise)\n");
+  fprintf(out, "      --recv-control=without|with : drop control characters from recv payload unless explicitly kept\n");
   fprintf(out, "      --recv-size=N   : maximum bytes returned by --recv\n");
   fprintf(out, "      --recv-timeout=DURATION : wait up to DURATION (ms|s) for recv\n");
   fprintf(out, "      --recv-until=STRING : wait until unread output contains STRING\n");
@@ -362,6 +376,12 @@ static void print_yaml_help(FILE *out, const char *program_name) {
   fprintf(out, "      requires: [--recv]\n");
   fprintf(out, "      default: escaped on TTY stdout, raw otherwise\n");
   fprintf(out, "      description: Select exact-byte or terminal-safe recv payload rendering.\n");
+  fprintf(out, "    - long: --recv-control\n");
+  fprintf(out, "      short: null\n");
+  fprintf(out, "      argument: without|with\n");
+  fprintf(out, "      default: without\n");
+  fprintf(out, "      requires: [--recv]\n");
+  fprintf(out, "      description: Drop control characters from recv payload unless explicitly kept.\n");
   fprintf(out, "  filter_operations:\n");
   fprintf(out, "    - long: --escape\n");
   fprintf(out, "      short: null\n");
@@ -1031,6 +1051,26 @@ static int write_recv_payload_raw(const char *data, uint32_t size) {
   return EXIT_SUCCESS;
 }
 
+static int is_recv_visible_byte(unsigned char byte) {
+  return byte >= 0x20 && byte <= 0x7e;
+}
+
+static size_t filter_recv_control_chars(const char *data, uint32_t size,
+                                        char *output) {
+  size_t in_offset;
+  size_t out_offset;
+
+  out_offset = 0;
+  for (in_offset = 0; in_offset < size; ++in_offset) {
+    unsigned char byte;
+
+    byte = (unsigned char)data[in_offset];
+    if (is_recv_visible_byte(byte))
+      output[out_offset++] = data[in_offset];
+  }
+  return out_offset;
+}
+
 static int format_byte_notation(FILE *out, const char *data, size_t size,
                                 int append_newline) {
   size_t offset;
@@ -1334,17 +1374,43 @@ static int request_recv_client(const char *socket_path, int session_id,
 
 static int print_recv_payload_and_status(
   const struct ptyterm_recv_response *response, const char *reason_override,
-  int recv_format) {
+  int recv_format, int recv_control_mode) {
   const char *data;
+  const char *output;
+  char *filtered;
+  uint32_t output_size;
 
   data = (const char *)(response + 1);
-  if (recv_format == PTYTERM_RECV_FORMAT_ESCAPED) {
-    if (write_recv_payload_escaped(data, response->returned_bytes) != EXIT_SUCCESS)
+  output = data;
+  output_size = response->returned_bytes;
+  filtered = NULL;
+
+  if (recv_control_mode == PTYTERM_RECV_CONTROL_WITHOUT &&
+      response->returned_bytes > 0) {
+    filtered = (char *)malloc(response->returned_bytes);
+    if (filtered == NULL) {
+      perror("malloc");
       return EXIT_FAILURE;
-  } else {
-    if (write_recv_payload_raw(data, response->returned_bytes) != EXIT_SUCCESS)
-      return EXIT_FAILURE;
+    }
+    output_size = (uint32_t)filter_recv_control_chars(data,
+                                                      response->returned_bytes,
+                                                      filtered);
+    output = filtered;
   }
+
+  if (recv_format == PTYTERM_RECV_FORMAT_ESCAPED) {
+    if (write_recv_payload_escaped(output, output_size) != EXIT_SUCCESS) {
+      free(filtered);
+      return EXIT_FAILURE;
+    }
+  } else {
+    if (write_recv_payload_raw(output, output_size) != EXIT_SUCCESS) {
+      free(filtered);
+      return EXIT_FAILURE;
+    }
+  }
+
+  free(filtered);
 
   print_recv_status_line(response->returned_bytes, response->start_offset,
                          response->end_offset, response->next_recv_offset,
@@ -1357,7 +1423,8 @@ static int print_recv_payload_and_status(
 static int run_recv_client(const char *socket_path, int session_id,
                            uint32_t recv_size, int recv_peek,
                            uint64_t recv_timeout_ms,
-                           const char *recv_until, int recv_format) {
+                           const char *recv_until, int recv_format,
+                           int recv_control_mode) {
   char payload[8192];
   const struct ptyterm_recv_response *response;
   uint64_t deadline_ms = 0;
@@ -1370,7 +1437,8 @@ static int run_recv_client(const char *socket_path, int session_id,
   if (recv_until == NULL && recv_timeout_ms == 0)
     return request_recv_client(socket_path, session_id, recv_size, recv_peek,
                                payload, sizeof(payload), &response) == EXIT_SUCCESS
-               ? print_recv_payload_and_status(response, NULL, recv_format)
+               ? print_recv_payload_and_status(response, NULL, recv_format,
+                                               recv_control_mode)
                : EXIT_FAILURE;
 
   until_size = recv_until == NULL ? 0 : strlen(recv_until);
@@ -1409,7 +1477,8 @@ static int run_recv_client(const char *socket_path, int session_id,
           EXIT_SUCCESS)
         return EXIT_FAILURE;
       return print_recv_payload_and_status(
-          response, recv_until == NULL ? NULL : "match_reached", recv_format);
+          response, recv_until == NULL ? NULL : "match_reached", recv_format,
+          recv_control_mode);
     }
 
     if (recv_until != NULL && response->returned_bytes == recv_size) {
@@ -2052,6 +2121,7 @@ int main(int argc, char *const argv[]) {
   int list_requested = 0;
   int recv_peek = 0;
   int recv_format = PTYTERM_RECV_FORMAT_AUTO;
+  int recv_control_mode = PTYTERM_RECV_CONTROL_WITHOUT;
   int filter_mode = PTYTERM_FILTER_MODE_NONE;
   const char *recv_until = NULL;
   uint64_t recv_timeout_ms = 0;
@@ -2076,6 +2146,7 @@ int main(int argc, char *const argv[]) {
       OPT_UNESCAPE,
       OPT_RECV,
       OPT_RECV_FORMAT,
+      OPT_RECV_CONTROL,
       OPT_RECV_SIZE,
       OPT_RECV_TIMEOUT,
       OPT_RECV_UNTIL,
@@ -2103,6 +2174,7 @@ int main(int argc, char *const argv[]) {
                        {"unescape", no_argument, NULL, OPT_UNESCAPE},
                        {"recv", no_argument, NULL, OPT_RECV},
                        {"recv-format", required_argument, NULL, OPT_RECV_FORMAT},
+                       {"recv-control", required_argument, NULL, OPT_RECV_CONTROL},
                        {"recv-size", required_argument, NULL, OPT_RECV_SIZE},
                        {"recv-timeout", required_argument, NULL, OPT_RECV_TIMEOUT},
                        {"recv-until", required_argument, NULL, OPT_RECV_UNTIL},
@@ -2181,6 +2253,11 @@ int main(int argc, char *const argv[]) {
       if (recv_format < 0)
         return usage_error(argv[0], "unsupported recv-format: %s", optarg);
       break;
+    case OPT_RECV_CONTROL:
+      recv_control_mode = parse_recv_control_mode(optarg);
+      if (recv_control_mode < 0)
+        return usage_error(argv[0], "unsupported recv-control: %s", optarg);
+      break;
     case OPT_PEEK:
       recv_peek = 1;
       break;
@@ -2255,6 +2332,8 @@ int main(int argc, char *const argv[]) {
     return usage_error(argv[0], "--peek requires --recv");
   if (recv_format != PTYTERM_RECV_FORMAT_AUTO && !recv_requested)
     return usage_error(argv[0], "--recv-format requires --recv");
+  if (recv_control_mode != PTYTERM_RECV_CONTROL_WITHOUT && !recv_requested)
+    return usage_error(argv[0], "--recv-control requires --recv");
   if ((recv_timeout_ms != 0 || recv_until != NULL) && !recv_requested)
     return usage_error(argv[0], "recv wait options require --recv");
   if (filter_mode != PTYTERM_FILTER_MODE_NONE && (ifile || ofile || afile))
@@ -2351,7 +2430,8 @@ int main(int argc, char *const argv[]) {
       return run_send_client(socket_path, session_id, send_data);
     if (recv_requested)
       return run_recv_client(socket_path, session_id, recv_size, recv_peek,
-                             recv_timeout_ms, recv_until, recv_format);
+                             recv_timeout_ms, recv_until, recv_format,
+                             recv_control_mode);
     return run_buffer_info_client(socket_path, session_id, status_format);
   }
 

--- a/src/test-ptyterm-create.sh
+++ b/src/test-ptyterm-create.sh
@@ -41,6 +41,36 @@ printf '%s\n' "$create_out" | grep -q '^session_id=1$' || {
   exit 1
 }
 
+printf '%s\n' "$create_out" | grep -q "^Next actions:$" || {
+  echo "ptyterm --create: expected next actions guidance" >&2
+  printf '%s\n' "$create_out" >&2
+  exit 1
+}
+
+printf '%s\n' "$create_out" | grep -q "Reuse --socket=$sock with the commands below\." || {
+  echo "ptyterm --create: expected socket reuse guidance" >&2
+  printf '%s\n' "$create_out" >&2
+  exit 1
+}
+
+printf '%s\n' "$create_out" | grep -q "^  \./ptyterm --session=1 --send='echo hello\\\\n'$" || {
+  echo "ptyterm --create: expected send guidance" >&2
+  printf '%s\n' "$create_out" >&2
+  exit 1
+}
+
+printf '%s\n' "$create_out" | grep -q '^  \./ptyterm --session=1 --recv$' || {
+  echo "ptyterm --create: expected recv guidance" >&2
+  printf '%s\n' "$create_out" >&2
+  exit 1
+}
+
+printf '%s\n' "$create_out" | grep -q '^  \./ptyterm --help$' || {
+  echo "ptyterm --create: expected help guidance" >&2
+  printf '%s\n' "$create_out" >&2
+  exit 1
+}
+
 sleep 1
 
 list_out=$(./ptyterm --list --socket="$sock" 2>&1) || {

--- a/src/test-ptyterm-help-format.sh
+++ b/src/test-ptyterm-help-format.sh
@@ -60,3 +60,15 @@ printf '%s\n' "$out" | grep -q 'long: --unescape' || {
   printf '%s\n' "$out" >&2
   exit 1
 }
+
+printf '%s\n' "$out" | grep -q 'description: Send input to one managed session' || {
+  echo "ptyterm --help-format=yaml: expected send example description" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+}
+
+printf '%s\n' "$out" | grep -q "command: \".*--session=1 --recv\"" || {
+  echo "ptyterm --help-format=yaml: expected recv example command" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+}

--- a/src/test-ptyterm-help.sh
+++ b/src/test-ptyterm-help.sh
@@ -126,6 +126,24 @@ printf '%s\n' "$out" | grep -q -- "--recv-until=STRING" || {
   exit 1
 }
 
+printf '%s\n' "$out" | grep -q -- "Examples:" || {
+  echo "ptyterm -h: expected examples section" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+}
+
+printf '%s\n' "$out" | grep -q -- "--session=1 --send='echo hello\\\\n'" || {
+  echo "ptyterm -h: expected send example in output" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+}
+
+printf '%s\n' "$out" | grep -q -- "--session=1 --recv" || {
+  echo "ptyterm -h: expected recv example in output" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+}
+
 printf '%s\n' "$out" | grep -q -- "--peek" || {
   echo "ptyterm -h: expected peek option in output" >&2
   printf '%s\n' "$out" >&2

--- a/src/test-ptyterm-recv-format.sh
+++ b/src/test-ptyterm-recv-format.sh
@@ -58,10 +58,10 @@ script -q -c "exec ./ptyterm --recv --recv-size=4 --session=1 --socket='$sock' 2
 }
 
 tr -d '\r' <"$tmpdir/tty.out" >"$tmpdir/tty.norm"
-printf '%s\n' 'A\n\\\e' >"$tmpdir/expected.out"
+printf '%s\n' 'A\\' >"$tmpdir/expected.out"
 
 cmp "$tmpdir/expected.out" "$tmpdir/tty.norm" || {
-  echo "ptyterm --recv on tty: expected escaped payload plus newline" >&2
+  echo "ptyterm --recv on tty: expected escaped payload with control chars removed" >&2
   od -An -tx1 "$tmpdir/tty.norm" >&2 || true
   od -An -tx1 "$tmpdir/expected.out" >&2 || true
   cat "$tmpdir/recv.err" >&2 || true
@@ -73,5 +73,31 @@ grep -q 'recv 4 bytes' "$tmpdir/recv.err" || {
   echo "ptyterm --recv on tty: expected recv status output on stderr" >&2
   cat "$tmpdir/recv.err" >&2 || true
   cat "$tmpdir/tty.err" >&2 || true
+  exit 1
+}
+
+./ptyterm --send='A\n\\\e' --session=1 --socket="$sock" >/dev/null 2>"$tmpdir/send-with.err" || {
+  echo "ptyterm --send for recv-control: expected success" >&2
+  cat "$tmpdir/send-with.err" >&2 || true
+  exit 1
+}
+
+script -q -c "exec ./ptyterm --recv --recv-control=with --recv-size=4 --session=1 --socket='$sock' 2>'$tmpdir/recv-with.err'" /dev/null >"$tmpdir/tty-with.out" 2>"$tmpdir/tty-with.err" || {
+  echo "ptyterm --recv --recv-control=with on tty: expected success" >&2
+  cat "$tmpdir/tty-with.out" >&2 || true
+  cat "$tmpdir/recv-with.err" >&2 || true
+  cat "$tmpdir/tty-with.err" >&2 || true
+  exit 1
+}
+
+tr -d '\r' <"$tmpdir/tty-with.out" >"$tmpdir/tty-with.norm"
+printf '%s\n' 'A\n\\\e' >"$tmpdir/expected-with.out"
+
+cmp "$tmpdir/expected-with.out" "$tmpdir/tty-with.norm" || {
+  echo "ptyterm --recv --recv-control=with on tty: expected escaped payload including control chars" >&2
+  od -An -tx1 "$tmpdir/tty-with.norm" >&2 || true
+  od -An -tx1 "$tmpdir/expected-with.out" >&2 || true
+  cat "$tmpdir/recv-with.err" >&2 || true
+  cat "$tmpdir/tty-with.err" >&2 || true
   exit 1
 }


### PR DESCRIPTION
## Summary
- add --recv-control=without|with and make control-character filtering the default for --recv
- extend the recv-format test to cover both filtered and explicit pass-through behavior
- add repository Copilot agents and a src-scoped instruction for Code Librarian style guidance

## Validation
- make check